### PR TITLE
Add new nextUntil function, rename previous nextUntil to nextAll

### DIFF
--- a/src/selector/traversals.js
+++ b/src/selector/traversals.js
@@ -5,36 +5,19 @@
         factory(window.Zepto || window.jQuery);
     }
 }(function($) {
-    function _all($element, method, selector) {
+    function _all($element, method, until, filter) {
         var $els = $();
-        var $el = $element[method]();
+        var $current = $element;
 
-        while ($el.length) {
-            if (typeof selector === 'undefined' || $el.is(selector)) {
-                $els = $els.add($el);
-                $el = $el[method]();
-            } else {
-                break;
-            }
-        }
+        until = until || [];
+        filter = filter || '';
 
-        return $els;
-    }
+        do {
+            $current = $current[method]().not(until);
+            $els = $els.add($current);
+        } while ($current.length);
 
-    function _until($element, method, selector, filter) {
-        var $els = $();
-        var $el = $element[method]();
-
-        while ($el.length && !$el.is(selector)) {
-            if (typeof filter === 'undefined' || $el.is(filter)) {
-                $els = $els.add($el);
-                $el = $el[method]();
-            } else {
-                break;
-            }
-        }
-
-        return $els;
+        return $els.filter(filter);
     }
 
     $.extend($.fn, {
@@ -43,8 +26,8 @@
          * match selector if it's defined or all of them if it isn't, until an
          * element that does not match selector is met.
          */
-        prevAll: function(selector) {
-            return _all(this, 'prev', selector);
+        prevAll: function(filter) {
+            return _all(this, 'prev', false, filter);
         },
 
         /*
@@ -52,8 +35,8 @@
          * match selector if it's defined or all of them if it isn't, until an
          * element that does not match selector is met.
          */
-        nextAll: function(selector) {
-            return _all(this, 'next', selector);
+        nextAll: function(filter) {
+            return _all(this, 'next', false, filter);
         },
 
         /*
@@ -61,15 +44,11 @@
          * optionally match 'filter' until an element that matches 'selector' is met,
          * not including the element matched by 'selector'.
          *
-         * When 'selector' is undefined the return value is identical to 'prevAll'
+         * When 'until' is undefined the return value is identical to 'prevAll'
          * with an undefined 'selector' argument; 'prevAll' is called instead.
          */
-        prevUntil: function(selector, filter) {
-            if (typeof selector === 'undefined') {
-                return _all(this, 'prev');
-            }
-
-            return _until(this, 'prev', selector, filter);
+        prevUntil: function(until, filter) {
+            return _all(this, 'prev', until, filter);
         },
 
         /*
@@ -77,15 +56,11 @@
          * optionally match 'filter' until an element that matches 'selector' is met,
          * not including the element matched by 'selector'.
          *
-         * When 'selector' is undefined the return value is identical to 'nextAll'
+         * When 'until' is undefined the return value is identical to 'nextAll'
          * with an undefined 'selector' argument; 'nextAll' is called instead.
          */
-        nextUntil: function(selector, filter) {
-            if (typeof selector === 'undefined') {
-                return _all(this, 'next');
-            }
-
-            return _until(this, 'next', selector, filter);
+        nextUntil: function(until, filter) {
+            return _all(this, 'next', until, filter);
         }
     });
 }));

--- a/tests/fixtures/list.html
+++ b/tests/fixtures/list.html
@@ -1,0 +1,14 @@
+<div class="x-links">
+    <a href="#" class="c-link">Link 1</a>
+    <a href="#">Link 2</a>
+    <a href="#" class="c-link">Link 3</a>
+    <button>Button</button>
+    <a href="#">Link 4</a>
+    <a href="#" class="c-link">Link 5</a>
+    <a href="#">Link 6</a>
+    <a href="#" class="c-link">Link 7</a>
+    <a href="#" class="c-link">Link 8</a>
+    <a href="#" class="c-link">Link 9</a>
+    <a href="#" class="c-link">Link 10</a>
+    <a href="#" class="c-link">Link 11</a>
+</div>

--- a/tests/runner/main.js
+++ b/tests/runner/main.js
@@ -11,7 +11,8 @@ require(['config'], function() {
                 '../../tests/unit/utils/capitalizeTests.js',
                 '../../tests/unit/utils/anyTests.js',
                 '../../tests/unit/utils/formatTests.js',
-                '../../tests/unit/selector/removeStyleTests.js'
+                '../../tests/unit/selector/removeStyleTests.js',
+                '../../tests/unit/selector/traversalTests.js'
             ];
 
             require(tests, function() {

--- a/tests/unit/selector/traversalTests.js
+++ b/tests/unit/selector/traversalTests.js
@@ -1,0 +1,74 @@
+define([
+    'text!fixtures/list.html',
+    '$',
+    'src/selector/traversals'
+], function(fixture, $) {
+    var $list = $(fixture).filter('.x-links');
+
+    var siblings = $list.children().length - 1;
+
+    var $firstLink = $list.children('a').first();
+    var $lastLink = $list.children('a').last();
+
+    // prevAll/nextAll
+    // ===============
+    //
+    describe('prevAll', function() {
+        it('returns all previous siblings with no parameters', function() {
+            assert.equal($lastLink.prevAll().length, siblings);
+        });
+
+        it('returns all previous siblings matching a selector', function() {
+            assert.equal($lastLink.prevAll('.c-link').length, 7);
+        });
+    });
+
+    describe('nextAll', function() {
+        it('returns all next siblings with no parameters', function() {
+            assert.equal($firstLink.nextAll().length, siblings);
+        });
+
+        it('returns all next siblings matching a selector', function() {
+            assert.equal($firstLink.nextAll('.c-link').length, 7);
+        });
+    });
+
+    // prevUntil/nextUntil
+    // ===================
+    //
+    describe('prevUntil', function() {
+        it('returns all previous siblings with no parameters', function() {
+            assert.equal($lastLink.prevUntil().length, siblings);
+        });
+
+        it('returns all previous siblings until the button', function() {
+            assert.equal($lastLink.prevUntil('button').length, 7);
+        });
+
+        it('returns all previous siblings until the button while filtering', function() {
+            assert.equal($lastLink.prevUntil('button', '.c-link').length, 5);
+        });
+
+        it('returns all previous siblings while filtering', function() {
+            assert.equal($lastLink.prevUntil(false, '.c-link').length, 7);
+        });
+    });
+
+    describe('nextUntil', function() {
+        it('returns all next siblings with no parameters', function() {
+            assert.equal($firstLink.nextUntil().length, siblings);
+        });
+
+        it('returns all next siblings with until the button', function() {
+            assert.equal($firstLink.nextUntil('button').length, 2);
+        });
+
+        it('returns all next siblings until the button while filtering', function() {
+            assert.equal($firstLink.nextUntil('button', '.c-link').length, 1);
+        });
+
+        it('returns all next siblings while filtering', function() {
+            assert.equal($firstLink.nextUntil(false, '.c-link').length, 7);
+        });
+    });
+});


### PR DESCRIPTION
prevUntil and nextUntil as written did not perform what I expected, returning a value akin to jQuery's prevAll and nextAll. This PR renames existing functions prevUntil and nextUntil to prevAll and nextAll, as well as adds more jQuery-like prevUntil and nextUntil functions instead. @ericmuyser provided me with a _until function he wrote.

Status: **Opened for review**

Reviewers: @hora @scalvert 
## Changes
- Renamed the helper function _until to _all
- Renamed prevUntil and nextUntil to prevAll and nextAll
- Added new _until helper function
- Added new prevUntil and nextUntil functions
- Added traversal tests
## How to test-drive this PR
- Install this branch into a project and compare behavior to a jQuery instance of nextAll and nextUntil
## Research resources
- http://api.jquery.com/nextall/
- http://api.jquery.com/nextuntil/
