### PR TITLE
scrollTo: for container option, make sure the container is not static

### DIFF
--- a/src/selector/scrollTo.js
+++ b/src/selector/scrollTo.js
@@ -9,24 +9,20 @@ define([
      * @returns {*|Zepto|jQuery}
      */
     $.scrollTo = function($target, options) {
+        var container;
+        var position;
         $target = $target || $('body');
         options = options || {};
 
-        if (options.container) {
-            var $container = $(options.container).first();
-            var container = $container[0];
+        // We need a plain DOM element for Velocity.animate when scrolling
+        // within a container
+        container = options.container && $(options.container).get(0);
 
-            // Ensure that the container is a plain DOM object, as that's what
-            // Velocity requires for non-jQuery environments
-            options.container = container;
+        if (container) {
+            position = window.getComputedStyle(container).position;
 
-            if ($container.css('position') === 'static') {
-                $container.css('position', 'relative');
-
-                console.warn('$.scrollTo: the given container must not use position:static, so we made it position:relative');
-                // From Velocity's doc:
-                // "The container element must have its CSS position property 
-                // set to either relative, absolute, or fixed — static will not work"
+            if (!position || position === 'static') {
+                throw container + ' needs to have a non-static position property';
             }
         }
 

--- a/src/selector/scrollTo.js
+++ b/src/selector/scrollTo.js
@@ -13,10 +13,20 @@ define([
         options = options || {};
 
         if (options.container) {
-            var $container = $(options.container);
+            var $container = $(options.container).first();
+            var container = $container[0];
+
+            // Ensure that the container is a plain DOM object, as that's what
+            // Velocity requires for non-jQuery environments
+            options.container = container;
+
             if ($container.css('position') === 'static') {
                 $container.css('position', 'relative');
+
                 console.warn('$.scrollTo: the given container must not use position:static, so we made it position:relative');
+                // From Velocity's doc:
+                // "The container element must have its CSS position property 
+                // set to either relative, absolute, or fixed — static will not work"
             }
         }
 
@@ -32,12 +42,6 @@ define([
      */
     $.fn.scrollTo = function(options) {
         return this.each(function() {
-            /**
-             * Ensure that the container is a plain DOM object, as that's what
-             * Velocity requires for non-jQuery environments
-             */
-            options.container && options.container.length && (options.container = $(options.container)[0]);
-
             return $.scrollTo($(this), options);
         });
     };

--- a/src/selector/scrollTo.js
+++ b/src/selector/scrollTo.js
@@ -16,6 +16,7 @@ define([
 
         // We need a plain DOM element for Velocity.animate when scrolling
         // within a container
+        // http://julian.com/research/velocity/#scroll
         container = options.container && $(options.container).get(0);
 
         if (container) {

--- a/src/selector/scrollTo.js
+++ b/src/selector/scrollTo.js
@@ -12,6 +12,14 @@ define([
         $target = $target || $('body');
         options = options || {};
 
+        if (options.container) {
+            var $container = $(options.container);
+            if ($container.css('position') === 'static') {
+                $container.css('position', 'relative');
+                console.warn('$.scrollTo: the given container must not use position:static, so we made it position:relative');
+            }
+        }
+
         Velocity.animate($target, 'scroll', options);
 
         return $target;


### PR DESCRIPTION
Status: ready to merge
Reviewer: @Helen-Mobify 

When passing in a container option, It's easy mistake to forget setting the css position for this container. This PR would make sure that the position is not `static`, and that it's at least `relative`.

From [Velocity's doc](http://julian.com/research/velocity/#scroll):
"The container element must have its CSS position property set to either relative, absolute, or fixed — static will not work"